### PR TITLE
added link to repository in documentation

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -90,7 +90,8 @@ test the installed version:
 Installation from Repository
 ----------------------------
 
-You can setup the development version under Windows and Linux.
+You can setup the development version under Windows and Linux using the
+`source code repository <https://github.com/fossasia/kniteditor/>`__.
 
 .. _installation-repository-linux:
 


### PR DESCRIPTION
Problem: I wanted to find out where the repositorz is in the section that talks about installing from the repository.

Solution: I linked to the repository in the beginning.